### PR TITLE
Rework parser

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"strings"
 	"unicode"
-	"unicode/utf8"
 )
 
 // parse splits s into all segments separated by sep and returns a slice of
@@ -16,26 +15,134 @@ import (
 //     - curly braces are only allowed enclosing a whole segment;
 //     - a variable name must be a vald Go identifier or *;
 //     - an empty segment is only allowed as the last part;
+//     - static segment values are percent decoded;
 //
 // Example:
 //
 //     // returns three parts: static "foo", variable "bar" and wildcard ""
 //     parts, err := parse("/foo/{bar}/{*}", '/')
-func parse(s string, sep byte) ([]part, error) {
-	if i := strings.IndexByte(s, sep); i == 0 {
-		s = s[1:]
+func parse(pattern string, sep byte) ([]part, error) {
+
+	index := 0 // index in pattern to beginning of next segment
+	if sep == '/' {
+		if len(pattern) == 0 || pattern[0] != '/' {
+			return nil, fmt.Errorf("%q: path pattern must start with '/'", pattern)
+		}
+		index = 1
 	}
-	n, r := 1, rune(sep)
-	for _, v := range s {
-		if v == r {
-			n++
+
+	var parts []part
+	for index <= len(pattern) {
+
+		i := strings.IndexByte(pattern[index:], sep)
+		if i < 0 {
+			i = len(pattern[index:])
+		}
+		segment := pattern[index : index+i]
+		index += i + 1
+
+		switch {
+		case segment == "":
+			switch {
+			case sep == '.':
+				return nil, fmt.Errorf("%q: empty segment not allowed", pattern)
+			case index <= len(pattern):
+				return nil, fmt.Errorf("%q: empty segment not allowed in middle of pattern", pattern)
+			}
+			parts = append(parts, part{typ: staticPart, val: segment})
+		case segment[0] == '{':
+			if segment[len(segment)-1] != '}' {
+				return nil, fmt.Errorf("%q: malformed variable specification %q", pattern, segment)
+			}
+			name := segment[1 : len(segment)-1]
+			switch name {
+			case "":
+				return nil, fmt.Errorf("%q: empty variable name not allowed", pattern)
+			case "*":
+				if index <= len(pattern) {
+					return nil, fmt.Errorf("%q: {*} not allowed in middle of pattern", pattern)
+				}
+				parts = append(parts, part{typ: wildcardPart})
+			default:
+				for i, r := range name {
+					if r == '_' || unicode.IsLetter(r) {
+						continue
+					}
+					if i > 0 && unicode.IsDigit(r) {
+						continue
+					}
+					return nil, fmt.Errorf("%q: invalid variable name %q", pattern, name)
+				}
+				parts = append(parts, part{typ: variablePart, val: name})
+			}
+		default:
+			if strings.IndexByte(segment, '{') >= 0 || strings.IndexByte(segment, '}') >= 0 {
+				return nil, fmt.Errorf("%q: '{' and '}' not allowed in pattern segment", pattern)
+			}
+			if sep == '/' {
+				var err error
+				segment, err = percentDecode(segment)
+				if err != nil {
+					return nil, err
+				}
+			}
+			parts = append(parts, part{typ: staticPart, val: segment})
 		}
 	}
-	p := parser{src: s, sep: r, dst: make([]part, n)}
-	if err := p.parseParts(); err != nil {
-		return nil, err
+	return parts, nil
+}
+
+// -----------------------------------------------------------------------------
+
+func isHex(b byte) bool {
+	return '0' <= b && b <= '9' ||
+		'a' <= b && b <= 'f' ||
+		'A' <= b && b <= 'F'
+}
+
+func hexValue(b byte) byte {
+	if b <= '9' {
+		return b & 0xf
+	} else {
+		return 9 + (b & 0xf)
 	}
-	return p.dst, nil
+}
+
+func percentDecode(s string) (string, error) {
+	n := 0
+	for i := 0; i < len(s); {
+		if s[i] != '%' {
+			i++
+		} else if i+2 < len(s) && isHex(s[i+1]) && isHex(s[i+2]) {
+			i += 3
+			n += 1
+		} else {
+			s = s[i:]
+			if len(s) > 3 {
+				s = s[:3]
+			}
+			return "", fmt.Errorf("bad percent escape %q", s)
+		}
+	}
+	if n == 0 {
+		return s, nil
+	}
+
+	p := make([]byte, len(s)-2*n)
+	j := 0
+	for i := 0; i < len(s); {
+		b := s[i]
+		if b != '%' {
+			p[j] = b
+			i++
+			j++
+		} else {
+			p[j] = hexValue(s[i+1])<<4 | hexValue(s[i+2])
+			i += 3
+			j++
+		}
+	}
+	return string(p), nil
 }
 
 // -----------------------------------------------------------------------------
@@ -65,110 +172,3 @@ type part struct {
 }
 
 // -----------------------------------------------------------------------------
-
-const eof = -1
-
-// parser parses the declaration syntax.
-type parser struct {
-	src string
-	sep rune
-	pos int
-	idx int
-	dst []part
-}
-
-// next returns the next rune in the input.
-func (p *parser) next() rune {
-	if p.pos >= len(p.src) {
-		return eof
-	}
-	r, w := utf8.DecodeRuneInString(p.src[p.pos:])
-	p.pos += w
-	return r
-}
-
-// setPart adds a part to the destination slice.
-func (p *parser) setPart(typ partType, val string) {
-	p.dst[p.idx] = part{typ: typ, val: val}
-	p.idx++
-}
-
-// parseParts consumes all parts recursively.
-//
-// The separator was already consumed when this method is called.
-func (p *parser) parseParts() error {
-	pin := p.pos
-	switch p.next() {
-	case eof:
-		p.setPart(staticPart, "")
-		return nil
-	case '{':
-		if err := p.parseVariable(); err != nil {
-			return err
-		}
-		val := p.src[pin+1 : p.pos-1]
-		if val == "*" {
-			p.setPart(wildcardPart, "")
-		} else {
-			p.setPart(variablePart, val)
-		}
-		switch p.next() {
-		case eof:
-			return nil
-		case p.sep:
-			return p.parseParts()
-		}
-		return p.errorf("unexpected characters after variable declaration")
-	case p.sep:
-		return p.errorf("unexpected double %q", p.sep)
-	}
-	for {
-		switch p.next() {
-		case p.sep:
-			p.setPart(staticPart, p.src[pin:p.pos-1])
-			return p.parseParts()
-		case eof:
-			p.setPart(staticPart, p.src[pin:p.pos])
-			return nil
-		case '{', '}':
-			return p.errorf("variables must be at the start of a segment")
-		}
-	}
-}
-
-// parseVariable consumes the variable name including the closing curly brace.
-//
-// The opening curly brace was already consumed when this method is called.
-func (p *parser) parseVariable() error {
-	switch r := p.next(); {
-	case r == eof:
-		return p.errorf("unexpected eof after '{'")
-	case r == '*':
-		if r = p.next(); r != '}' {
-			return p.errorf("expected '}' after '*'")
-		}
-		if r = p.next(); r != eof {
-			return p.errorf("expected eof after '{*}'")
-		}
-		return nil
-	case r != '_' && !unicode.IsLetter(r):
-		return p.errorf("expected underscore or letter starting a variable name; got %q", r)
-	}
-	for {
-		switch r := p.next(); {
-		case r == '}':
-			return nil
-		case r == eof:
-			return p.errorf("unexpected eof in variable name")
-		case r == p.sep:
-			return p.errorf("missing '}' in variable declaration")
-		case r != '_' && !unicode.IsLetter(r) && !unicode.IsDigit(r):
-			return p.errorf("unexpected %q in variable name", r)
-		}
-	}
-}
-
-// errorf returns an error prefixed by the string being parsed.
-func (p *parser) errorf(format string, args ...interface{}) error {
-	return fmt.Errorf(fmt.Sprintf("%q: %s", p.src, format), args...)
-}

--- a/parser_test.go
+++ b/parser_test.go
@@ -60,6 +60,15 @@ var parserTests = []parserTest{
 		{variablePart, "bar"},
 		{wildcardPart, ""},
 	}},
+	{"/foo%2fbar", []part{
+		{staticPart, "foo/bar"},
+	}},
+	{"/%E4%B8%96%E7%95%8C", []part{
+		{staticPart, "世界"},
+	}},
+	{"/%25", []part{
+		{staticPart, "%"},
+	}},
 	// parsing errors
 	{"//foo", nil},     // double separator
 	{"/fo{o", nil},     // variable delimiter in static part
@@ -69,8 +78,12 @@ var parserTests = []parserTest{
 	{"/{foo", nil},     // unclosed variable
 	{"/{foo}}", nil},   // too closed variable
 	{"/{*}/", nil},     // wildcard in bad place
+	{"/foo/{*}/", nil}, // wildcard in bad place
 	{"/{*name}", nil},  // invalid variable name
 	{"/{1name}", nil},  // invalid variable name
+	{"junk", nil},      // path does not start with /
+	{"/%2x", nil},      // invalid percent encoding
+	{"/%2", nil},       // invalid percent encoding
 }
 
 func TestParsePaths(t *testing.T) {


### PR DESCRIPTION
I am not sure that this parser is any better than the original. Perhaps I should write a couple of benchmarks to see how they compare.  

This PR does change a couple of things:

- '/' is required at the start of a path pattern.
- Static part values are percent decoded.  Dispatch will need to match on
      decoded path segments, so also decode in pattern parser.